### PR TITLE
DWT scraper skipped the headline every time, fixed

### DIFF
--- a/scripts/dwtonline.js
+++ b/scripts/dwtonline.js
@@ -26,20 +26,36 @@ class Source extends Main {
         let counter = 0;
 
         // Search HTML and collect values
-        $('ul.homelist li').first().find('li:not(.first)').each((i, element) => {
+        $('ul.homelist li').first().find('li').each((i, element) => {
 
-          // Create item object
-          items[i] = {
-            id: '',
-            title: $(element).children('a').text().split('-')[1].trim(),
-            url: self.sourceUrl + $(element).children('a').attr('href').trim(),
-            date: '',
-            author: '',
-            image: {
-              url: '',
-              alt: ''
-            },
-            content: ''
+          if ($(element).hasClass('first')) {
+            // Create item object
+            items[i] = {
+              id: '',
+              title: $(element).children('h2').children('a').text().trim(),
+              url: self.sourceUrl + $(element).children('h2').children('a').attr('href').trim(),
+              date: '',
+              author: '',
+              image: {
+                url: '',
+                alt: ''
+              },
+              content: ''
+            }
+          } else {
+            // Create item object
+            items[i] = {
+              id: '',
+              title: $(element).children('a').text().split('-')[1].trim(),
+              url: self.sourceUrl + $(element).children('a').attr('href').trim(),
+              date: '',
+              author: '',
+              image: {
+                url: '',
+                alt: ''
+              },
+              content: ''
+            }
           }
 
           // Get single item content


### PR DESCRIPTION
On the website there are 4 news items, but the scraper detected 3. Skipped the headline.
Fixed by detecting the headline element too.
![image](https://user-images.githubusercontent.com/11035568/50286190-637a8200-043d-11e9-9416-703094ca2464.png)
